### PR TITLE
allow setting of default settings

### DIFF
--- a/Source/jQuery.addObject.js
+++ b/Source/jQuery.addObject.js
@@ -21,7 +21,9 @@ jQuery.addObject = function(name, object){
 			return this;
 		}
 		if (instance) return instance;
-		this.data(name, new object(this.selector, arg));
+		options = $.extend({}, jQuery.fn[name].defaults, arg);
+		this.data(name, new object(this.selector, options));
 		return this;
 	};
+	jQuery.fn[name].defaults = {};
 };


### PR DESCRIPTION
it should be possible for jQuery Plugins to set some default values. I added two lines sothat it is possible to use $.fn.pluginName.defaults to set some default values that are used over the ones defined in the original code.

unit tests are missing though. If you consider accepting the pull request I'd be glad to write some.
